### PR TITLE
Fix to ensure the requestCode is always 16 bit

### DIFF
--- a/index.js
+++ b/index.js
@@ -13,8 +13,11 @@ export function checkPermission(perm) {
 export function requestPermission(perm) {
     if(typeof perm == "string") perm = [perm];
 
-    let r = Math.random() * (perm[0].length||1);
-    let permCode = Math.round(r + (new Date().getTime())/1000);
+    // permCode greater than 16 bits causes an error so limit code to max of 65535
+    let maximum = 65535;
+    let minimum = 1;
+
+    let permCode = Math.floor(Math.random() * (maximum - minimum + 1)) + minimum;
 
     return NativeModules.RNPermissionsAndroid.requestPermission(perm, permCode);
 };


### PR DESCRIPTION
Currently the requestCode passed into requestPermission can be larger than 16 bit which can cause the error seen in the attached screenshot. This change just ensures that the random number generated is always 16 bit.

![16bit](https://cloud.githubusercontent.com/assets/8040808/19603933/f3c7847c-97aa-11e6-90c7-32a177c0410d.png)
